### PR TITLE
Fixing midi-winmm support for windows.

### DIFF
--- a/lib/unimidi/adapter/midi-winmm.rb
+++ b/lib/unimidi/adapter/midi-winmm.rb
@@ -5,7 +5,7 @@ module UniMIDI
   module Adapter
 
     # Load underlying devices using the midi-winmm gem
-    module MIDIWinMM
+    module MIDIWinMMAdapter
 
       module Loader
 


### PR DESCRIPTION
This commit removed "Adapter" from the module name, which broke Unimidi for windows when using midi-winmm. 
https://github.com/arirusso/unimidi/commit/56c0d49193b041561ea5475924f1377790376435
