### PR TITLE
Specify minitest 4.7.5 as 5.x is incompatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "minitest", "4.7.5"
   gem "mocha"
   gem "rake"
   gem "shoulda-context"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift dir + '/../lib'
 
+gem "minitest", "4.7.5"
 require "test/unit"
 require "mocha/test_unit"
 require "shoulda-context"


### PR DESCRIPTION
Without this, the tests were picking up on newer version of minitest, which deprecates all of the Test::Unit::\* classes.
