### PR TITLE
add help output to the command line client

### DIFF
--- a/bin/unimidi
+++ b/bin/unimidi
@@ -4,8 +4,20 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 
 require "unimidi"
 
-opts = ARGV.length > 1 ? ARGV.slice(1, ARGV.length-1) : {} 
-  
-raise "No command specified" if ARGV.first.nil? 
- 
+def help_exit(argv = nil)
+  if argv == nil
+    puts "No command specified"
+  else
+    puts "Subcommmand #{argv.to_s} not found"
+  end
+  puts "Usage: unimidi list"
+  puts "  You can also pass `l` or `list_devices`, but they mean the same thing"
+  exit 1
+end
+
+opts = ARGV.length > 1 ? ARGV.slice(1, ARGV.length-1) : {}
+
+help_exit if ARGV.first.nil?
+
+
 UniMIDI::Command.exec(ARGV.first.to_sym, opts)

--- a/bin/unimidi
+++ b/bin/unimidi
@@ -6,7 +6,7 @@ require "unimidi"
 
 def help_exit(argv = nil)
   if argv == nil
-    puts "No command specified"
+    puts "No subcommand specified"
   else
     puts "Subcommmand #{argv.to_s} not found"
   end

--- a/lib/unimidi/command.rb
+++ b/lib/unimidi/command.rb
@@ -17,7 +17,7 @@ module UniMIDI
         Output.list
         true
       else
-        raise "Command #{command.to_s} not found"
+        help_exit(command)
       end   
     end
 


### PR DESCRIPTION
Add some helpful output to the command-line client, in case you don't pass a parameter or you pass an invalid parameter. My intention was to do this without adding any additional gem requirements, so it's fairly basic. I'm also not 100% certain that putting the 'help_exit' method in the bin/unimidi file is idiomatic ruby, but I couldn't think of a better place to put it.
