### PR TITLE
Improve clarity of UniMIDI::Input methods

### DIFF
--- a/lib/unimidi/input.rb
+++ b/lib/unimidi/input.rb
@@ -1,111 +1,20 @@
+require "unimidi/input/buffer_access"
+require "unimidi/input/stream_reader"
+
 module UniMIDI
 
   # A MIDI input device
   class Input
 
     extend Device::ClassMethods
+    include BufferAccess
     include Device::InstanceMethods
+    include StreamReader
 
     # All MIDI input devices -- used to populate the class
     # @return [Array<Input>]
     def self.all
       Loader.devices(:direction => :input)
-    end
-
-    # The device buffer
-    # @return [Array<Hash>]
-    def buffer
-      @device.buffer
-    end
-
-    #
-    # Plucks data from the input buffer and returns it as array of MIDI event hashes as such:
-    #   [
-    #     { :data => [144, 60, 100], :timestamp => 1024 },
-    #     { :data => [128, 60, 100], :timestamp => 1100 },
-    #     { :data => [144, 40, 120], :timestamp => 1200 }
-    #   ]
-    #
-    # In this case, the data is an array of Numeric bytes
-    # The timestamp is the number of millis since this input was enabled
-    # Arguments are passed to the underlying device object
-    #
-    # @param [*Object] args
-    # @return [Array<Hash>]
-    def gets(*args)
-      @device.gets(*args)
-    rescue SystemExit, Interrupt
-      exit
-    end
-
-    #
-    # Plucks data from the input buffer and returns it as array of MIDI event hashes.
-    # Similar to Input#gets except that the returned message data as string of hex digits eg:
-    #   [
-    #     { :data => "904060", :timestamp => 904 },
-    #     { :data => "804060", :timestamp => 1150 },
-    #     { :data => "90447F", :timestamp => 1300 }
-    #   ]
-    #
-    # @param [*Object] args
-    # @return [Array<Hash>]
-    def gets_s(*args)
-      @device.gets_s(*args)
-    rescue SystemExit, Interrupt
-      exit
-    end
-    alias_method :gets_bytestr, :gets_s
-    alias_method :gets_hex, :gets_s
-
-    #
-    # Plucks data from the input buffer and returns it as an array of data bytes such as
-    #   [144, 60, 100, 128, 60, 100, 144, 40, 120]
-    #
-    # @param [*Object] args
-    # @return [Array<Fixnum>]
-    def gets_data(*args)
-      arr = gets(*args)
-      arr.map { |msg| msg[:data] }.inject(:+)
-    end
-
-    #
-    # Plucks data from the input buffer and returns it as a string of data such as
-    #   "90406080406090447F"
-    #
-    # @param [*Object] args
-    # @return [String]
-    def gets_data_s(*args)
-      arr = gets_bytestr(*args)
-      arr.map { |msg| msg[:data] }.join
-    end
-    alias_method :gets_data_bytestr, :gets_data_s
-    alias_method :gets_data_hex, :gets_data_s
-
-    # Clears the input buffer
-    # @return [Array]
-    def clear_buffer
-      @device.buffer.clear
-    end
-
-    # Gets any messages in the buffer in the same format as Input#gets, without removing them from the buffer
-    # @param [*Object] args
-    # @return [Array<Hash>]
-    def gets_buffer(*args)
-      @device.buffer
-    end
-
-    # Gets any messages in the buffer in the same format as Input#gets_s, without removing them from the buffer
-    # @param [*Object] args
-    # @return [Array<Hash>]
-    def gets_buffer_s(*args)
-      @device.buffer.map { |msg| msg[:data] = TypeConversion.numeric_byte_array_to_hex_string(msg[:data]); msg }
-    end
-
-    # Gets any messages in the buffer in the same format as Input#gets_data without removing them from the buffer
-    # @param [*Object] args
-    # @return [Array<Fixnum>]
-    def gets_buffer_data(*args)
-      @device.buffer.map { |msg| msg[:data] }
     end
 
   end

--- a/lib/unimidi/input/buffer_access.rb
+++ b/lib/unimidi/input/buffer_access.rb
@@ -16,22 +16,24 @@ module UniMIDI
         @device.buffer.clear
       end
 
-      # Gets any messages in the buffer in the same format as Input#gets. This doesn't remove the messages from the
-      # buffer or have any effect on
+      # Gets any messages in the buffer in the same format as Input::StreamReader#gets. This doesn't remove
+      # the messages from the buffer or have any effect on the StreamReader pointer position
       # @param [*Object] args
       # @return [Array<Hash>]
       def gets_buffer(*args)
         @device.buffer
       end
 
-      # Gets any messages in the buffer in the same format as Input#gets_s, without removing them from the buffer
+      # Gets any messages in the buffer in the same format as Input#gets_s. This doesn't remove
+      # the messages from the buffer or have any effect on the StreamReader pointer position
       # @param [*Object] args
       # @return [Array<Hash>]
       def gets_buffer_s(*args)
         @device.buffer.map { |msg| msg[:data] = TypeConversion.numeric_byte_array_to_hex_string(msg[:data]); msg }
       end
 
-      # Gets any messages in the buffer in the same format as Input#gets_data without removing them from the buffer
+      # Gets any messages in the buffer in the same format as Input#gets_data. . This doesn't remove
+      # the messages from the buffer or have any effect on the StreamReader pointer position
       # @param [*Object] args
       # @return [Array<Fixnum>]
       def gets_buffer_data(*args)

--- a/lib/unimidi/input/buffer_access.rb
+++ b/lib/unimidi/input/buffer_access.rb
@@ -1,0 +1,45 @@
+module UniMIDI
+
+  class Input
+
+    module BufferAccess
+
+      # The device buffer
+      # @return [Array<Hash>]
+      def buffer
+        @device.buffer
+      end
+
+      # Clears the input buffer
+      # @return [Array]
+      def clear_buffer
+        @device.buffer.clear
+      end
+
+      # Gets any messages in the buffer in the same format as Input#gets. This doesn't remove the messages from the
+      # buffer or have any effect on
+      # @param [*Object] args
+      # @return [Array<Hash>]
+      def gets_buffer(*args)
+        @device.buffer
+      end
+
+      # Gets any messages in the buffer in the same format as Input#gets_s, without removing them from the buffer
+      # @param [*Object] args
+      # @return [Array<Hash>]
+      def gets_buffer_s(*args)
+        @device.buffer.map { |msg| msg[:data] = TypeConversion.numeric_byte_array_to_hex_string(msg[:data]); msg }
+      end
+
+      # Gets any messages in the buffer in the same format as Input#gets_data without removing them from the buffer
+      # @param [*Object] args
+      # @return [Array<Fixnum>]
+      def gets_buffer_data(*args)
+        @device.buffer.map { |msg| msg[:data] }
+      end
+
+    end
+
+  end
+
+end

--- a/lib/unimidi/input/stream_reader.rb
+++ b/lib/unimidi/input/stream_reader.rb
@@ -1,0 +1,75 @@
+module UniMIDI
+
+  class Input
+
+    module StreamReader
+
+      # Plucks data from the input buffer and returns it as array of MIDI event hashes as such:
+      #
+      # The data is returned as array of MIDI event hashes as such:
+      #   [
+      #     { :data => [144, 60, 100], :timestamp => 1024 },
+      #     { :data => [128, 60, 100], :timestamp => 1100 },
+      #     { :data => [144, 40, 120], :timestamp => 1200 }
+      #   ]
+      #
+      # In this case, the data is an array of Numeric bytes
+      # The timestamp is the number of millis since this input was enabled
+      # Arguments are passed to the underlying device object
+      #
+      # @param [*Object] args
+      # @return [Array<Hash>]
+      def gets(*args)
+        @device.gets(*args)
+      rescue SystemExit, Interrupt
+        exit
+      end
+
+      #
+      # Plucks data from the input buffer and returns it as array of MIDI event hashes.
+      # Similar to Input#gets except that the returned message data as string of hex digits eg:
+      #   [
+      #     { :data => "904060", :timestamp => 904 },
+      #     { :data => "804060", :timestamp => 1150 },
+      #     { :data => "90447F", :timestamp => 1300 }
+      #   ]
+      #
+      # @param [*Object] args
+      # @return [Array<Hash>]
+      def gets_s(*args)
+        @device.gets_s(*args)
+      rescue SystemExit, Interrupt
+        exit
+      end
+      alias_method :gets_bytestr, :gets_s
+      alias_method :gets_hex, :gets_s
+
+      #
+      # Plucks data from the input buffer and returns it as an array of data bytes such as
+      #   [144, 60, 100, 128, 60, 100, 144, 40, 120]
+      #
+      # @param [*Object] args
+      # @return [Array<Fixnum>]
+      def gets_data(*args)
+        arr = gets(*args)
+        arr.map { |msg| msg[:data] }.inject(:+)
+      end
+
+      #
+      # Plucks data from the input buffer and returns it as a string of data such as
+      #   "90406080406090447F"
+      #
+      # @param [*Object] args
+      # @return [String]
+      def gets_data_s(*args)
+        arr = gets_bytestr(*args)
+        arr.map { |msg| msg[:data] }.join
+      end
+      alias_method :gets_data_bytestr, :gets_data_s
+      alias_method :gets_data_hex, :gets_data_s
+
+    end
+
+  end
+
+end

--- a/lib/unimidi/input/stream_reader.rb
+++ b/lib/unimidi/input/stream_reader.rb
@@ -4,7 +4,9 @@ module UniMIDI
 
     module StreamReader
 
-      # Plucks data from the input buffer and returns it as array of MIDI event hashes as such:
+      # Returns any data in the input buffer that have been received since the last call to a
+      # StreamReader method. If a StreamReader method has not yet been called, all data received
+      # since the program was initialized will be returned
       #
       # The data is returned as array of MIDI event hashes as such:
       #   [
@@ -25,8 +27,10 @@ module UniMIDI
         exit
       end
 
+      # Returns any data in the input buffer that have been received since the last call to a
+      # StreamReader method. If a StreamReader method has not yet been called, all data received
+      # since the program was initialized will be returned
       #
-      # Plucks data from the input buffer and returns it as array of MIDI event hashes.
       # Similar to Input#gets except that the returned message data as string of hex digits eg:
       #   [
       #     { :data => "904060", :timestamp => 904 },
@@ -44,8 +48,11 @@ module UniMIDI
       alias_method :gets_bytestr, :gets_s
       alias_method :gets_hex, :gets_s
 
+      # Returns any data in the input buffer that have been received since the last call to a
+      # StreamReader method. If a StreamReader method has not yet been called, all data received
+      # since the program was initialized will be returned
       #
-      # Plucks data from the input buffer and returns it as an array of data bytes such as
+      # Similar to Input#gets except that the returned message data as an array of data bytes such as
       #   [144, 60, 100, 128, 60, 100, 144, 40, 120]
       #
       # @param [*Object] args
@@ -55,8 +62,11 @@ module UniMIDI
         arr.map { |msg| msg[:data] }.inject(:+)
       end
 
+      # Returns any data in the input buffer that have been received since the last call to a
+      # StreamReader method. If a StreamReader method has not yet been called, all data received
+      # since the program was initialized will be returned
       #
-      # Plucks data from the input buffer and returns it as a string of data such as
+      # Similar to Input#gets except that the returned message data as a string of data such as
       #   "90406080406090447F"
       #
       # @param [*Object] args


### PR DESCRIPTION
Addresses https://github.com/arirusso/unimidi/issues/39

The documentation for *UniMIDI::Input* is lacking clarity in how the various methods interact with the data buffer

This branch extracts *UniMIDI::Input* instance methods into two additional modules *UniMIDI::Input::StreamReader* and *UniMIDI::Input::BufferAccess*.  The documentation for those methods is then improved upon in those modules